### PR TITLE
SFO Bug/Compatibility with MIH_SP: Update ui_spell_system_elemental.tph

### DIFF
--- a/dw_talents/sfo/lua/ui_spell_system_elemental.tph
+++ b/dw_talents/sfo/lua/ui_spell_system_elemental.tph
@@ -271,7 +271,7 @@ DEFINE_PATCH_FUNCTION analyse_elemental_type_core INT_VAR opcode=0 resource_offs
 			END		
 		END
 		12 BEGIN
-			READ_SHORT 0xa+fx_off dmg_type
+			READ_SHORT 0xa+resource_offset dmg_type
 			PATCH_MATCH "%dmg_type%" WITH 
 			1 BEGIN
 				earth=1


### PR DESCRIPTION
Hey there ! I had an issue with the install for this. Surprised myself catching this one so quickly. Kinda proud of myself tbh.

Issue:
dw_talents : bloodline sorcerers wouldn't install due to a conflict with MIH_SP, with their spell sunburst (SPWI827). 
```
[./override/SPWI827.spl] loaded, 634 bytes
Copying and patching 1 file ...
Copying and patching 1 file ...
[./override/MH#SUNBU.eff] loaded, 272 bytes
ERROR: illegal 2-byte read from offset 548 of 272-byte file MH#SUNBU.eff
ERROR: [MH#SUNBU.eff] -> [nowhere] Patching Failed (COPY) (Failure("MH#SUNBU.eff: read out of bounds"))
Stopping installation because of error.
ERROR: [SPWI827.spl] -> [nowhere] Patching Failed (COPY) (Failure("MH#SUNBU.eff: read out of bounds"))
Stopping installation because of error.
```
Looks like it's one of the only spells that goes through most of the logic for `analyse_elemental_type`. There was a typo on line 274: `fx_off` should be `resource_offset`.
