### PR TITLE
Update kit_cm.tpa - fix duplicate force mage

### DIFF
--- a/dw_talents/kit/kit_cm.tpa
+++ b/dw_talents/kit/kit_cm.tpa
@@ -9,7 +9,6 @@ DEFINE_ACTION_FUNCTION kit_cm BEGIN
 
 	
 	ACTION_DEFINE_ASSOCIATIVE_ARRAY cm_list BEGIN
-		force_mage_of_mystra=>""
 		wild_mage_of_mystra=>""
 		illusionist_of_baervan=>""
 		abjurer_of_ilmater=>""


### PR DESCRIPTION
If you don't install force mages initially, then multi-class cleric mages can't be installed due to a duplicate line.

I also added the label for force-mage, so it actually does something.